### PR TITLE
Fixed fetchPopularRepos error handler

### DIFF
--- a/app/components/Popular.js
+++ b/app/components/Popular.js
@@ -104,7 +104,7 @@ export default class Popular extends React.Component {
             }
           }))
         })
-        .catch(() => {
+        .catch((error) => {
           console.warn('Error fetching repos: ', error)
 
           this.setState({


### PR DESCRIPTION
Otherwise `console.warn('Error fetching repos: ', error)` can cause "error is undefined".